### PR TITLE
Add Explicit Tag to Search

### DIFF
--- a/BuildAndInstallPlugin.bat
+++ b/BuildAndInstallPlugin.bat
@@ -1,5 +1,5 @@
 
 dotnet build -c Release
 taskkill /F /IM PowerToys.exe
-robocopy /e /w:5 "%~dp0\bin\Release\net8.0-windows" "C:\Program Files\PowerToys\RunPlugins\PowerToys-Run-Spotify"
+robocopy /e /w:5 "%~dp0\bin\Release\net8.0-windows" "C:\Program Files\PowerToys Run\Plugins\PowerToys-Run-Spotify"
 start "" "C:\Program Files\PowerToys\PowerToys.exe"

--- a/Main.cs
+++ b/Main.cs
@@ -123,7 +123,7 @@ public class Main : IPlugin, IContextMenu, ISettingProvider
             results.AddRange(searchResponse.Tracks.Items.Select(track => new Result
             {
                 Title = track.Name,
-                SubTitle = $"Song • By {string.Join(", ", track.Artists.Select(x => x.Name))}",
+                SubTitle = $"Song{(track.Explicit ? " • Explicit" : "")} • By {string.Join(", ", track.Artists.Select(x => x.Name))}",
                 Icon = () => new BitmapImage(new Uri(track.Album.Images.OrderBy(x => x.Width * x.Height).First().Url)),
                 ContextData = new ContextData
                 {


### PR DESCRIPTION
Change Log:
- When searching for a song, it’s not always clear whether it is explicit, which can lead to the wrong version playing. To address this issue, I have added the text "Explicit" to the subtitle for better clarity.
- Fixed the path for the plugin folder in the bat file

Before:
![image](https://github.com/user-attachments/assets/24489bf2-70a5-44ec-a997-ee1f4899b11d)

After:
![image](https://github.com/user-attachments/assets/2d254026-94c8-4029-8cc4-83c41056a121)
