### PR TITLE
Basic Playlist Support

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -1,4 +1,4 @@
-﻿using Wox.Plugin;
+﻿ using Wox.Plugin;
 using System.Windows.Controls;
 using Microsoft.PowerToys.Settings.UI.Library;
 using System.Windows.Media.Imaging;
@@ -183,6 +183,30 @@ public class Main : IPlugin, IContextMenu, ISettingProvider
                     return true;
                 }
             }));
+
+        if (searchResponse.Playlists.Items != null)
+        {
+            results.AddRange(searchResponse.Playlists.Items.Where(playlist => playlist != null).Select(playlist => new Result
+            {
+                    Title = playlist.Name,
+                    SubTitle = "Playlist",
+                    Icon = () => new BitmapImage(new Uri(playlist.Images.OrderBy(x => x.Width * x.Height).First().Url)),
+                    ContextData = new ContextData
+                    {
+                        ResultType = ResultType.Playlist,
+                        Uri = playlist.Uri
+                    },
+                    Action = context =>
+                    {
+                        _ = EnsureActiveDevice(
+                            async (player, request) => await player.ResumePlayback(request),
+                            new PlayerResumePlaybackRequest { ContextUri = playlist.Uri}
+                        );
+                        return true;
+                    }
+                
+            }));
+        }
 
         foreach (var result in results)
             result.Score = GetScore(result.Title, query.Search);

--- a/Main.cs
+++ b/Main.cs
@@ -1,4 +1,4 @@
-﻿ using Wox.Plugin;
+﻿using Wox.Plugin;
 using System.Windows.Controls;
 using Microsoft.PowerToys.Settings.UI.Library;
 using System.Windows.Media.Imaging;


### PR DESCRIPTION
Simple PR adding basic support for searching for playlists.

#5 Would suggest that playlist support is already present, but it after a fresh install on my laptop to double check it doesn't seem to work. Looking at the code in main.cs theres no way apart to handle playlists so I don't know?

This doesn't directly access the user clients made playlists so I'm unsure if it would work for private playlists; however, the search api can return your own playlist (maybe not if private). Hence if these playlists are listened to a lot, they will have favourable rankings and appear at the top. Below are some screenshots or it showing my own personal playlist and a random one from search. Hence this someway fixed #27 in a sense. Also this allows you to more effectively search and play lofi playlists when studying :)

![image](https://github.com/user-attachments/assets/545d1bc8-5158-4089-9d6c-f869a52dfde2)
![image](https://github.com/user-attachments/assets/cc4a4920-01cd-4b1b-8074-4db574dc7a9a)

Also sorry I won't be too available to improve it in future I need to focus on uni exams atm. I threw it together in like 30 mins so may not be perfect but works well enough for me.

Thanks for making this in the first place by the way

