### PR TITLE
Fix build bat

### DIFF
--- a/BuildAndInstallPlugin.bat
+++ b/BuildAndInstallPlugin.bat
@@ -1,5 +1,7 @@
-
+@echo on
+cd "%~dp0\"
 dotnet build -c Release
 taskkill /F /IM PowerToys.exe
 robocopy /e /w:5 "%~dp0\bin\Release\net9.0-windows" "C:\Program Files\PowerToys\RunPlugins\PowerToys-Run-Spotify"
 start "" "C:\Program Files\PowerToys\PowerToys.exe"
+pause

--- a/BuildAndInstallPlugin.bat
+++ b/BuildAndInstallPlugin.bat
@@ -1,7 +1,5 @@
-@echo on
 cd "%~dp0\"
 dotnet build -c Release
 taskkill /F /IM PowerToys.exe
 robocopy /e /w:5 "%~dp0\bin\Release\net9.0-windows" "C:\Program Files\PowerToys\RunPlugins\PowerToys-Run-Spotify"
 start "" "C:\Program Files\PowerToys\PowerToys.exe"
-pause


### PR DESCRIPTION
Me again, the .bat file wasn't finding the correct directory when running it so I pulled a cd "%~dp0\" Might not be necessary if you're running the script from an IDE but wasn't working for me when running manually from explorer. You'll have to try it cuz I'm assuming youre running it from VS.