### PR TITLE
ADD: References to the DLL are removed in the release to avoid incons…

### DIFF
--- a/PowerToys-Run-Spotify.csproj
+++ b/PowerToys-Run-Spotify.csproj
@@ -18,15 +18,19 @@
     <ItemGroup>
         <Reference Include="PowerToys.Common.UI">
             <HintPath>libs\PowerToys.Common.UI.dll</HintPath>
+            <Private>false</Private>
         </Reference>
         <Reference Include="PowerToys.ManagedCommon">
             <HintPath>libs\PowerToys.ManagedCommon.dll</HintPath>
+            <Private>false</Private>
         </Reference>
         <Reference Include="PowerToys.Settings.UI.Lib">
-            <HintPath>libs\PowerToys.Settings.UI.Lib</HintPath>
+            <HintPath>libs\PowerToys.Settings.UI.Lib.dll</HintPath>
+            <Private>false</Private>
         </Reference>
         <Reference Include="Wox.Plugin">
             <HintPath>libs\Wox.Plugin.dll</HintPath>
+            <Private>false</Private>
         </Reference>
     </ItemGroup>
 


### PR DESCRIPTION
#76 This is because the new version has changes in the libraries it uses; the reference has been removed from the build to avoid inconsistencies.
Just build again, take the contents of the Release, and put them in the plugin folder.